### PR TITLE
feat(赞助): 随喜签式申请展示入口重设计

### DIFF
--- a/direction-approved.md
+++ b/direction-approved.md
@@ -1,0 +1,44 @@
+# 设计方向确认 · 赞助页 CTA 按钮重设计
+
+**日期:** 2026-08-05
+**分支:** worktree-sponsor-cta-redesign
+
+## 背景
+
+本次为「赞助前端重设计」任务：为赞助页 `/about/sponsor` 的 CTA 按钮
+（原为普通 outline Button「已赞助 · 申请展示」）设计手工定制按钮，
+对齐友链页 `NameCardButton`（名帖母题）的定制水准。
+
+视觉语言已定（竹林水墨 spec，`bamboo-ink-design` skill 硬约束），
+故三方向为**同一语言内的母题差异化诠释**，非风格发散。
+
+## 三方向初稿
+
+三版 HTML 初稿（含默认态 + hover 态预览）存放于：
+- `~/.claude/jobs/7006afb4/tmp/design-demos/方向A-随喜签.html`
+- `~/.claude/jobs/7006afb4/tmp/design-demos/方向B-题名入册.html`
+- `~/.claude/jobs/7006afb4/tmp/design-demos/方向C-谢帖回执.html`
+
+| 方向 | 母题 | 结构签名 |
+|---|---|---|
+| A · 随喜签 | 随喜结缘（铜钱） | 方孔圆钱右上 + 竖排「随喜」签条 + 右下折角 |
+| B · 题名入册 | 感恩账册 | 深绿实底签条 + 笔刷下划线 + 谢字水印 |
+| C · 谢帖回执 | 与拜帖对偶 | 折角卡同构 + 竖排「谢帖」签条 |
+
+## 用户选择
+
+> 赞助页「已赞助·申请展示」CTA 按钮选哪个母题方向？
+> **「A · 随喜签（铜钱）」** —— 用户原话选择项：
+> 「方孔圆钱 + 竖排『随喜』签条，母题最独特、识别度最高，紧扣『随喜之门』章节词汇。」
+
+用户补充要求（原话）：
+> 「但是摆放位置要求跟 friend 一样，在右侧才对」
+
+即：按钮摆放位置与友链页一致，放在 hero **右侧**（原 CTA 在左栏 intro 下方，
+改为 friends 同款双栏布局——左栏开场文案、右栏「随喜结缘」竖排题跋 + 随喜签按钮）。
+
+## 落地
+
+- 新增 `SuixiSignButton` 组件（`frontend/src/routes/about/sponsor.tsx`）
+- hero 改双栏 grid（`lg:grid-cols-12`），按钮移至右栏，配竖排「随喜结缘」题跋
+- 移除原 outline Button 与 `Button` import

--- a/frontend/src/routes/about/sponsor.tsx
+++ b/frontend/src/routes/about/sponsor.tsx
@@ -14,7 +14,6 @@ import type { SponsorChannel, SponsorRecord } from '@/api/types'
 import type { MotionDivProps } from '@/lib/motion'
 import { getPublicChannels, getPublicRecords } from '@/api/sponsor'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
-import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { BambooArt, EnsoEmpty } from '@/components/ink-wash'
 import { enter } from '@/lib/motion'
@@ -50,6 +49,73 @@ function splitAmount(cents: number): { int: string; dec: string } {
   return { int, dec }
 }
 
+/**
+ * 随喜签款行动入口：方孔圆钱压签 + 竖排「随喜」签条 + 双行文案。
+ *
+ * 母题：「随喜结缘」典出随喜之门——赞助即随喜，申请展示如递上一张随喜签。
+ * 方孔圆钱是「随喜之资」的东方符号，压于签纸右上，hover 时被轻轻拿起旋转；
+ * 签纸摆正、浮起、右下折角翻开，即双手呈上之态。折角在右下（区别于友链
+ * 拜帖的右上折角）。色彩字体一律走 styles.css token。
+ */
+function SuixiSignButton() {
+  return (
+    <Link
+      to="/operate/sponsor"
+      className="group/suixi relative inline-flex rotate-[-1.4deg] items-stretch overflow-hidden rounded-sm border border-leaf-deep/35 bg-card shadow-[0_3px_10px_-3px_oklch(0.32_0.06_155/0.22)] transition-[translate,rotate,border-color,box-shadow] duration-300 hover:-translate-y-1.5 hover:rotate-0 hover:border-leaf-deep hover:shadow-[0_18px_36px_-14px_oklch(0.32_0.06_155/0.38)]"
+    >
+      {/* 方孔圆钱：随喜之资，hover 浮起微转 */}
+      <span
+        aria-hidden
+        className="absolute right-[9px] top-[9px] size-[25px] text-leaf-deep/55 transition-[translate,rotate,color] duration-300 group-hover/suixi:-translate-y-[3px] group-hover/suixi:rotate-[9deg] group-hover/suixi:text-leaf-deep"
+      >
+        <svg viewBox="0 0 24 24" fill="none" className="size-full">
+          <circle
+            cx="12"
+            cy="12"
+            r="9.2"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          />
+          <rect
+            x="8.4"
+            y="8.4"
+            width="7.2"
+            height="7.2"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          />
+        </svg>
+      </span>
+      {/* 右下折角：纸的背面，hover 时翻开一角 */}
+      <span
+        aria-hidden
+        className="absolute bottom-0 right-0 size-[20px] transition-[width,height] duration-300 group-hover/suixi:size-[25px]"
+        style={{
+          background:
+            'linear-gradient(225deg, oklch(0.9 0.05 120) 0%, oklch(0.82 0.07 130) 48%, oklch(0.94 0.03 115) 52%, oklch(0.97 0.02 110) 100%)',
+          clipPath: 'polygon(100% 0, 0 100%, 100% 100%)',
+        }}
+      />
+      {/* 竖排「随喜」签条 */}
+      <span
+        aria-hidden
+        className="flex w-[34px] shrink-0 items-center justify-center border-r border-leaf-deep/20 bg-leaf-deep/9 py-3 [writing-mode:vertical-rl] [text-orientation:upright] font-serif text-[13px] font-bold tracking-[0.3em] text-leaf-deep"
+      >
+        随喜
+      </span>
+      {/* 正文：衬线主标 + mono 副标 */}
+      <span className="py-3.5 pl-5 pr-6 text-left">
+        <span className="block font-serif text-[17px] font-bold leading-tight tracking-[0.08em] text-text-primary transition-colors group-hover/suixi:text-leaf-deep">
+          投一分心意
+        </span>
+        <span className="mt-0.5 block font-mono text-[10px] uppercase tracking-[0.22em] text-text-secondary">
+          随喜入册 · Apply
+        </span>
+      </span>
+    </Link>
+  )
+}
+
 function SponsorPage() {
   const reduced = useReducedMotion() ?? false
   const channelsQuery = useQuery({
@@ -81,78 +147,97 @@ function SponsorPage() {
         <BambooArt className="pointer-events-none absolute -left-16 bottom-0 h-[70%] w-[480px] -scale-x-100 text-text-primary" />
 
         <div className="relative z-10 mx-auto w-full max-w-6xl px-6 md:px-10 pb-20 pt-36">
-          <motion.p
-            {...enter(reduced, 0.1, {
-              initial: { opacity: 0, y: 16 },
-              animate: { opacity: 1, y: 0 },
-              transition: { duration: 0.6, ease: 'easeOut' },
-            })}
-            className="flex items-center gap-4 font-mono text-[11px] uppercase tracking-[0.35em] text-text-secondary"
-          >
-            <span className="h-px w-10 bg-leaf-deep" />
-            赞助 · 感恩录
-          </motion.p>
-
-          <motion.h1
-            {...enter(reduced, 0.2, {
-              initial: { opacity: 0, y: 24 },
-              animate: { opacity: 1, y: 0 },
-              transition: { duration: 0.7, ease: [0.22, 0.9, 0.3, 1] as const },
-            })}
-            className="mt-7 font-serif text-[clamp(3.4rem,9.5vw,6.5rem)] font-bold leading-[1.05] tracking-[0.03em] text-text-primary"
-          >
-            感恩<span className="text-leaf-deep">有你</span>
-          </motion.h1>
-
-          <motion.div
-            {...enter(reduced, 0.32, {
-              initial: { opacity: 0, scaleX: 0 },
-              animate: { opacity: 1, scaleX: 1 },
-              transition: { duration: 0.7, ease: [0.22, 0.9, 0.3, 1] as const },
-            })}
-            className="mt-5 origin-left"
-          >
-            <svg
-              className="block h-3 w-40 md:w-52"
-              viewBox="0 0 224 12"
-              aria-hidden
-            >
-              <path
-                d="M2 7 C 48 1 118 0 222 3 C 150 11 60 12 2 7 Z"
-                fill="var(--leaf-deep)"
-              />
-            </svg>
-          </motion.div>
-
-          <motion.p
-            {...enter(reduced, 0.42, {
-              initial: { opacity: 0, y: 16 },
-              animate: { opacity: 1, y: 0 },
-              transition: { duration: 0.7, ease: 'easeOut' },
-            })}
-            className="mt-7 max-w-xl font-serif text-lg italic leading-relaxed text-text-secondary md:text-xl"
-          >
-            每一份支持，都是竹林里的一缕清风。它让小站得以安静地生长，也让我知道有人在听。
-          </motion.p>
-
-          {/* 申请展示入口：实际赞助后递交申请，经核实后入册感恩账册 */}
-          <motion.div
-            {...enter(reduced, 0.52, {
-              initial: { opacity: 0, y: 16 },
-              animate: { opacity: 1, y: 0 },
-              transition: { duration: 0.7, ease: 'easeOut' },
-            })}
-            className="mt-10"
-          >
-            <Link to="/operate/sponsor">
-              <Button
-                variant="outline"
-                className="cursor-pointer rounded-md px-7 py-5 font-serif text-[15px] tracking-wide"
+          <div className="grid grid-cols-1 items-center gap-12 lg:grid-cols-12">
+            {/* ── 左栏 · 感恩帖开场 ── */}
+            <div className="lg:col-span-7">
+              <motion.p
+                {...enter(reduced, 0.1, {
+                  initial: { opacity: 0, y: 16 },
+                  animate: { opacity: 1, y: 0 },
+                  transition: { duration: 0.6, ease: 'easeOut' },
+                })}
+                className="flex items-center gap-4 font-mono text-[11px] uppercase tracking-[0.35em] text-text-secondary"
               >
-                已赞助 · 申请展示
-              </Button>
-            </Link>
-          </motion.div>
+                <span className="h-px w-10 bg-leaf-deep" />
+                赞助 · 感恩录
+              </motion.p>
+
+              <motion.h1
+                {...enter(reduced, 0.2, {
+                  initial: { opacity: 0, y: 24 },
+                  animate: { opacity: 1, y: 0 },
+                  transition: {
+                    duration: 0.7,
+                    ease: [0.22, 0.9, 0.3, 1] as const,
+                  },
+                })}
+                className="mt-7 font-serif text-[clamp(3.4rem,9.5vw,6.5rem)] font-bold leading-[1.05] tracking-[0.03em] text-text-primary"
+              >
+                感恩<span className="text-leaf-deep">有你</span>
+              </motion.h1>
+
+              <motion.div
+                {...enter(reduced, 0.32, {
+                  initial: { opacity: 0, scaleX: 0 },
+                  animate: { opacity: 1, scaleX: 1 },
+                  transition: {
+                    duration: 0.7,
+                    ease: [0.22, 0.9, 0.3, 1] as const,
+                  },
+                })}
+                className="mt-5 origin-left"
+              >
+                <svg
+                  className="block h-3 w-40 md:w-52"
+                  viewBox="0 0 224 12"
+                  aria-hidden
+                >
+                  <path
+                    d="M2 7 C 48 1 118 0 222 3 C 150 11 60 12 2 7 Z"
+                    fill="var(--leaf-deep)"
+                  />
+                </svg>
+              </motion.div>
+
+              <motion.p
+                {...enter(reduced, 0.42, {
+                  initial: { opacity: 0, y: 16 },
+                  animate: { opacity: 1, y: 0 },
+                  transition: { duration: 0.7, ease: 'easeOut' },
+                })}
+                className="mt-7 max-w-xl font-serif text-lg italic leading-relaxed text-text-secondary md:text-xl"
+              >
+                每一份支持，都是竹林里的一缕清风。它让小站得以安静地生长，也让我知道有人在听。
+              </motion.p>
+            </div>
+
+            {/* ── 右栏 · 随喜结缘题跋 + 随喜签（与左栏墨竹对望，案头呈签） ── */}
+            <div className="flex items-center justify-start gap-7 lg:col-span-5 lg:justify-end">
+              {/* 竖排题跋：随喜结缘之意，desktop 专属 */}
+              <motion.span
+                {...enter(reduced, 0.5, {
+                  initial: { opacity: 0, x: 12 },
+                  animate: { opacity: 1, x: 0 },
+                  transition: { duration: 0.7, ease: 'easeOut' },
+                })}
+                aria-hidden
+                className="hidden select-none font-serif text-sm tracking-[0.55em] text-text-secondary/80 [writing-mode:vertical-rl] [text-orientation:upright] lg:block"
+              >
+                随喜结缘
+              </motion.span>
+
+              {/* 随喜签：搁在案头微倾，hover 被拾起呈上 */}
+              <motion.div
+                {...enter(reduced, 0.58, {
+                  initial: { opacity: 0, y: 20, rotate: 6, scale: 0.94 },
+                  animate: { opacity: 1, y: 0, rotate: 0, scale: 1 },
+                  transition: { type: 'spring', stiffness: 220, damping: 15 },
+                })}
+              >
+                <SuixiSignButton />
+              </motion.div>
+            </div>
+          </div>
         </div>
       </section>
 

--- a/resources/frontend/dist/index.html
+++ b/resources/frontend/dist/index.html
@@ -28,12 +28,12 @@ https://opensource.org/licenses/MIT
       rel="stylesheet"
     />
     <title>Create TanStack App - bamboo-main-frontend</title>
-    <script type="module" crossorigin src="/assets/index-BG1WDKgY.js"></script>
+    <script type="module" crossorigin src="/assets/index-DDIcfZzM.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/useStore-DLYuMt2P.js">
     <link rel="modulepreload" crossorigin href="/assets/auth-CZ5zA9aQ.js">
     <link rel="modulepreload" crossorigin href="/assets/matchContext-CmoYCc9t.js">
     <link rel="modulepreload" crossorigin href="/assets/Match-B0H73BkJ.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-BTtj5NmU.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-BTzayTXK.css">
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
## 改动内容

赞助页 `/about/sponsor` 的「已赞助 · 申请展示」CTA 由普通 outline Button 升级为手工定制的 **随喜签** 按钮，对齐友链页 `NameCardButton`（名帖母题）的定制水准。

### 随喜签按钮（`SuixiSignButton`）
- 母题「随喜结缘」：呼应页内「壹·随喜之门」章节，赞助即随喜，申请展示如递上一张随喜签
- 方孔圆钱（随喜之资的东方符号）压于签纸右上，hover 浮起 3px 旋转 9° 染深叶绿
- 竖排「随喜」签条 + 衬线主标「投一分心意」/ mono 副标「随喜入册 · Apply」
- 右下折角（区别于友链拜帖的右上折角），hover 翻开

### 摆放位置对齐友链页
- hero 改为 `lg:grid-cols-12` 双栏布局，按钮移至**右栏**，配竖排「随喜结缘」题跋（desktop 专属），与左侧墨竹对望——与友链页「虚位以待 + 名帖」同构
- 按钮 spring 入场动画与友链名帖一致

### 验证
- `pnpm build`（vite + tsc）通过
- `pnpm exec eslint` 通过、prettier 已格式化
- playwright 实测：按钮中心位于右半屏（x=1159/1440）、铜钱/折角/签条/正文渲染齐全、hover 铜钱浮起旋转染绿、无 pageerror

设计决策记录见 `direction-approved.md`（三方向初稿 + 用户选择原话）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)